### PR TITLE
Allow the passing of server credentials as string instead of file path

### DIFF
--- a/src/Google/ServiceCredentials.php
+++ b/src/Google/ServiceCredentials.php
@@ -17,7 +17,18 @@ class ServiceCredentials extends DataTransferObject
             throw new InvalidArgumentException(sprintf('Service account configuration file not found: %s', $path));
         }
 
-        $config = json_decode(file_get_contents($path), true);
+        $json = file_get_contents($path);
+
+        return static::parseFromJSON($json);
+    }
+
+    public static function parseFromJSON(string $json): static
+    {
+        $config = json_decode($json, true);
+
+        if (json_last_error() !== JSON_ERROR_NONE) {
+            throw new InvalidArgumentException('Invalid JSON provided: '.json_last_error_msg());
+        }
 
         return new static([
             'client_id' => $config['client_id'],


### PR DESCRIPTION
Previously, server credentials for Google services had to be provided as a file path, which contains unencrypted security credentials. This commit introduces the ability to instantiate the ServiceCredentials class using the parseFromJSON method, allowing JSON strings to be passed directly as a parameter. This enables credentials to be stored  in environment variables instead of files.